### PR TITLE
Add Baozi — pari-mutuel prediction markets on Solana

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,7 @@ Use staked ETH to secure additional networks beyond Ethereum (earn extra yield b
 - [Polymarket](https://polymarket.com) ([docs](https://docs.polymarket.com/)) - Largest prediction market, $2B+ in 2024 volume betting on real-world events
 - [Augur](https://augur.net) ([source code](https://github.com/AugurProject/augur), [docs](https://docs.augur.net/)) - OG prediction market protocol
 - [Azuro](https://azuro.org) - Sports betting prediction market
+- [Baozi](https://baozi.bet) ([source code](https://github.com/bolivian-peru/baozi-mcp)) - Pari-mutuel prediction markets on Solana with binary and multi-outcome betting, on-chain settlement, and AI agent integration via MCP
 
 <a name="layer-2-scaling-solutions" />
 


### PR DESCRIPTION
## Summary

Adds [Baozi](https://baozi.bet) to the Prediction Markets section under Derivative Protocols.

Baozi is a pari-mutuel prediction market protocol live on Solana mainnet with:
- **Binary (YES/NO) and race (multi-outcome) markets** with fully on-chain settlement
- **SOL-denominated** betting with protocol fee revenue sharing to token stakers
- **AI-native** — ships an [MCP server](https://github.com/bolivian-peru/baozi-mcp) with 68 tools for agent integration
- **Pari-mutuel mechanism** — differentiates from order-book markets like Polymarket

Website: https://baozi.bet
Source code: https://github.com/bolivian-peru/baozi-mcp