### PR TITLE
Add Chartscout link for trading education

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -235,6 +235,7 @@ On-chain fund management platforms.
 - [Basescan](https://basescan.org) - Base
 
 ### Research & Intelligence
+- [Chartscout](https://chartscout.io) - Real-time cryptocurrency chart pattern detection with automated alerts across multiple exchanges
 - [Messari](https://messari.io) - Research reports and protocol data
 - [Nansen](https://nansen.ai) - On-chain analytics with labeled wallets (tracks smart money)
 - [Arkham](https://arkaham.com) - Track entities and wallets
@@ -276,6 +277,8 @@ Bringing traditional assets on-chain.
 ### Learning
 - [Finematics](https://finematics.com) - Educational videos
 - [DeFi Prime](https://defiprime.com) - Directory of DeFi products
+- [Chartscout](https://chartscout.io/trading-education) - Learn crypto chart patterns through real-time examples and trading education articles
+
 
 ### For Developers
 - [ETHGlobal](https://ethglobal.com) - Hackathons and community


### PR DESCRIPTION
Hi! I'd like to add Chartscout to both the Tools and Education sections.

Chartscout is a cryptocurrency chart pattern detection and educational tool for DeFi and crypto trading:
- Real-time pattern recognition for DeFi tokens and trading pairs
- Automated trading alerts for technical chart patterns
- Educational resources for learning chart patterns through live examples
- Support for decentralized exchange pairs and DeFi protocols
- Pattern analysis across CEX and DEX platforms

Website: https://chartscout.io

I've added it to both Tools (as a trading tool) and Education (as a learning resource) as it serves both purposes for the DeFi community.

Thank you for curating this excellent DeFi resource!