### PR TITLE
Add Web3 Trackers to Analytics > Research & Intelligence

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -239,6 +239,7 @@ On-chain fund management platforms.
 - [Nansen](https://nansen.ai) - On-chain analytics with labeled wallets (tracks smart money)
 - [Arkham](https://arkaham.com) - Track entities and wallets
 - [Glassnode](https://glassnode.com) - On-chain metrics and market intelligence
+- [Web3 Trackers](https://www.web3trackers.com) - Marketing attribution for DeFi: track which campaigns drive wallet connects and on-chain deposits
 
 <a name="misc" />
 


### PR DESCRIPTION
Adds [Web3 Trackers](https://www.web3trackers.com) to the **Research & Intelligence** subsection under Analytics.

Web3 Trackers is a marketing attribution platform for crypto teams — it connects marketing campaigns (UTM links, KOL posts, Discord invites) to on-chain conversions (wallet connects, deposits, swaps) across Ethereum, Base, Solana, and TON.

Fits alongside Nansen, Arkham, and Glassnode as an analytics tool that bridges off-chain campaign data with on-chain activity.