### PR TITLE
Add RustChain — Proof-of-Antiquity consensus blockchain

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -264,6 +264,9 @@ Bringing traditional assets on-chain.
 - [Snapshot](https://snapshot.org) ([source code](https://github.com/snapshot-labs)) - Gasless off-chain voting for DAOs
 - [Tally](https://tally.xyz) ([docs](https://docs.tally.xyz/)) - On-chain governance interface
 
+### Alternative Consensus
+- [RustChain](https://rustchain.org) ([source code](https://github.com/Scottcjn/rustchain), [docs](https://rustchain.org/llms.txt)) - Proof-of-Antiquity blockchain rewarding vintage hardware miners (PowerPC, Pentium 4) with RTC tokens. No ICO, no premine beyond 6% dev fund. Ergo chain anchoring, on-chain AI agent economy (RIP-302)
+
 <a name="community" />
 
 ## Community


### PR DESCRIPTION
Adds RustChain to the Misc section under a new "Alternative Consensus" subsection.

**What is RustChain?**
- Proof-of-Antiquity blockchain that rewards mining on vintage hardware (PowerPC G4, Pentium 4, IBM POWER8)
- RTC token with no ICO, no premine beyond 6% dev fund
- Ergo chain anchoring for cross-chain verification
- On-chain AI agent economy (RIP-302) with 544 RTC volume across 86 jobs
- 6-point hardware fingerprinting prevents VM farming
- Active network with 4 attestation nodes across 3 countries

**Links:**
- Website: https://rustchain.org
- Source: https://github.com/Scottcjn/rustchain
- Block Explorer: https://rustchain.org/explorer