### PR TITLE
Add FlashArb Scanner — free real-time DEX arbitrage tool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -209,6 +209,7 @@ On-chain fund management platforms.
 ### Advanced DeFi Tools
 - [DeFi Saver](https://defisaver.com) - Automation for lending positions (MakerDAO, Aave, Compound)
 - [Revert Finance](https://revert.finance) - Manage Uniswap V3 liquidity
+- [FlashArb Scanner](http://18.118.43.47/flasharb/) ([source code](https://github.com/JacobMazelin/flasharb-scanner)) - Free real-time DEX arbitrage scanner between Uniswap V3 and SushiSwap with flash loan profit calculations. Zero capital required.
 - [Instadapp](https://instadapp.io) ([source code](https://github.com/Instadapp)) - Smart wallet for advanced DeFi interactions
 
 ### Developer Infrastructure


### PR DESCRIPTION
## Adding FlashArb Scanner

**What it does:** Free real-time DEX arbitrage scanner between Uniswap V3 and SushiSwap with flash loan profit calculations.

**Why it belongs here:** 
- Fills a gap in the Advanced DeFi Tools section — no other free arbitrage scanner listed
- Uses flash loans (AAVE/Balancer V2) making it truly zero capital required  
- Open source: https://github.com/JacobMazelin/flasharb-scanner
- Live demo: http://18.118.43.47/flasharb/

**Section:** Advanced DeFi Tools (alongside DeFi Saver, Revert Finance, Instadapp)