### PR TITLE
Add Arch Tools — 61 AI tools with x402 USDC payments

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -214,6 +214,7 @@ On-chain fund management platforms.
 ### Developer Infrastructure
 - [The Graph](https://thegraph.com) ([source code](https://github.com/graphprotocol), [docs](https://thegraph.com/docs/)) - Index and query blockchain data
 - [WalletConnect](https://walletconnect.com) ([source code](https://github.com/WalletConnect), [docs](https://docs.walletconnect.com/)) - Connect wallets to dapps
+- [Arch Tools](https://archtools.dev) ([source code](https://github.com/Deesmo/Arch-AI-Tools), [docs](https://archtools.dev)) - 61 AI tools via REST API and MCP with native x402 USDC micropayments on Base, Polygon, Avalanche, and Solana
 
 <a name="analytics" />
 


### PR DESCRIPTION
Adds [Arch Tools](https://archtools.dev) to the Applications/Tools > Developer Infrastructure section.

**Arch Tools** provides 61 production-ready AI tools (code analysis, web scraping, image generation, NLP, crypto, search, and more) accessible via REST API and MCP protocol. Native x402 USDC micropayments on Base, Polygon, Avalanche, and Solana.

- **GitHub:** https://github.com/Deesmo/Arch-AI-Tools
- **MCP endpoint:** https://arch-tools-mcp.onrender.com/mcp
- **x402scan:** https://x402scan.com/resource/archtools.dev