### PR TITLE
Add SuiBets to Prediction Markets section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,7 @@ Use staked ETH to secure additional networks beyond Ethereum (earn extra yield b
 - [Polymarket](https://polymarket.com) ([docs](https://docs.polymarket.com/)) - Largest prediction market, $2B+ in 2024 volume betting on real-world events
 - [Augur](https://augur.net) ([source code](https://github.com/AugurProject/augur), [docs](https://docs.augur.net/)) - OG prediction market protocol
 - [Azuro](https://azuro.org) - Sports betting prediction market
+- [SuiBets](https://suibets.app) ([source code](https://github.com/elpou88/suibetsupdatedsecurity)) - Decentralized sports betting on Sui blockchain with SUI, SBETS & USDsui wagering. 700+ on-chain bets, live on mainnet.
 - [SuiBets](https://suibets.com) - Decentralized sports betting on Sui blockchain with verified smart contract and formal verification
 
 <a name="layer-2-scaling-solutions" />

--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,7 @@ Use staked ETH to secure additional networks beyond Ethereum (earn extra yield b
 - [Polymarket](https://polymarket.com) ([docs](https://docs.polymarket.com/)) - Largest prediction market, $2B+ in 2024 volume betting on real-world events
 - [Augur](https://augur.net) ([source code](https://github.com/AugurProject/augur), [docs](https://docs.augur.net/)) - OG prediction market protocol
 - [Azuro](https://azuro.org) - Sports betting prediction market
+- [SuiBets](https://suibets.com) - Decentralized sports betting on Sui blockchain with verified smart contract and formal verification
 
 <a name="layer-2-scaling-solutions" />
 

--- a/readme.md
+++ b/readme.md
@@ -152,7 +152,6 @@ Use staked ETH to secure additional networks beyond Ethereum (earn extra yield b
 - [Augur](https://augur.net) ([source code](https://github.com/AugurProject/augur), [docs](https://docs.augur.net/)) - OG prediction market protocol
 - [Azuro](https://azuro.org) - Sports betting prediction market
 - [SuiBets](https://suibets.app) ([source code](https://github.com/elpou88/suibetsupdatedsecurity)) - Decentralized sports betting on Sui blockchain with SUI, SBETS & USDsui wagering. 700+ on-chain bets, live on mainnet.
-- [SuiBets](https://suibets.com) - Decentralized sports betting on Sui blockchain with verified smart contract and formal verification
 
 <a name="layer-2-scaling-solutions" />
 


### PR DESCRIPTION
Adds [SuiBets](https://suibets.app) to the **Prediction Markets** section alongside Polymarket, Augur, and Azuro.

**SuiBets** is a decentralized sports betting platform live on Sui mainnet:
- Smart contract: [`0x2e354642...`](https://suiscan.xyz/mainnet/object/0x2e354642a3c00571832c03c42575587a0ca38cfe02e4f84cb3404cc9eab403d3)
- 700+ on-chain bets processed
- Supports SUI, SBETS & USDsui wagering
- Open source: [GitHub](https://github.com/elpou88/suibetsupdatedsecurity)
- DefiLlama adapter verified (.28k TVL)
- SBETS token traded on Cetus DEX (Sui largest DEX)