### PR TITLE
Add vaults.fyi to Analytics / DeFi Dashboards

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -221,6 +221,7 @@ On-chain fund management platforms.
 
 ### DeFi Dashboards
 - [DeFiLlama](https://defillama.com) ([source code](https://github.com/DefiLlama)) - Best DeFi data source: TVL, yields, stablecoins, unlocks across all chains
+- [vaults.fyi](https://vaults.fyi) - Discover, compare, and deposit into 1,000+ DeFi yield vaults across 20+ networks, with standardized APY, TVL, and risk metrics sourced from on-chain data. API for wallets, fintechs, and AI agents to embed yield
 - [Dune Analytics](https://dune.com) - Create custom dashboards with SQL queries on blockchain data
 - [Token Terminal](https://tokenterminal.com) - Protocol financials (revenue, fees, P/E ratios)
 


### PR DESCRIPTION
Adds vaults.fyi to the DeFi Dashboards section under Analytics. vaults.fyi connects users to yield from 80+ protocols across 20+ networks: a consumer app at app.vaults.fyi where users discover, compare, and deposit into 1,000+ vaults, plus an API used by wallets, fintechs, and AI agents (Kraken Wallet, Jumper, Maple Finance, Gauntlet) to embed yield in their applications. Yield, TVL, and risk metrics are standardized and sourced directly from on-chain data, which separates it from aggregators that rely on protocol-reported numbers. Placed directly below DeFiLlama as the closest functional analog (data platform with API).