### PR TITLE
Add Base Pay Desk

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -195,6 +195,9 @@ On-chain fund management platforms.
 
 ## Applications/Tools
 
+### Payments
+- [Base Pay Desk](https://oskarasi.github.io/base-pay-desk-site/) ([source code](https://github.com/oskarasi/base-pay-desk-site)) - Open-source Base ETH payment-link builder for merchants and service sellers
+
 ### Wallets
 - [MetaMask](https://metamask.io) ([source code](https://github.com/MetaMask), [docs](https://docs.metamask.io/)) - Most popular Ethereum wallet, built-in swaps
 - [Rainbow](https://rainbow.me) - Mobile-friendly Ethereum wallet


### PR DESCRIPTION
## Summary
- add Base Pay Desk under Applications/Tools as a payments tool
- link the live Base ETH payment-link builder and public source repo

## Validation
- git diff --check