### PR TITLE
Add Sharpe to DEX and trading analytics

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -228,6 +228,7 @@ On-chain fund management platforms.
 - [DEX Screener](https://dexscreener.com) - Real-time charts for any DEX pair across all chains
 - [GeckoTerminal](https://geckoterminal.com) - DEX analytics by CoinGecko
 - [Dex.Guru](https://dex.guru) - Advanced DEX trading terminal
+- [Sharpe](https://www.sharpe.ai) - Crypto trading intelligence for DEX flow, derivatives positioning, arbitrage, narratives, stablecoins, and exchange listings
 
 ### Block Explorers
 - [Etherscan](https://etherscan.io) - Ethereum


### PR DESCRIPTION
Adds Sharpe under Analytics -> DEX & Trading.

This list separates DeFi applications from analytics resources. Sharpe fits the analytics side, closer to DEX Screener, GeckoTerminal, and Dex.Guru than to wallets or protocol infrastructure, because it helps traders read DEX flow, derivatives positioning, arbitrage, stablecoins, and narrative rotation.

Disclosure: I work on Sharpe.