### PR TITLE
Add Stablesonar to Analytics → DeFi Dashboards

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -223,6 +223,7 @@ On-chain fund management platforms.
 - [DeFiLlama](https://defillama.com) ([source code](https://github.com/DefiLlama)) - Best DeFi data source: TVL, yields, stablecoins, unlocks across all chains
 - [Dune Analytics](https://dune.com) - Create custom dashboards with SQL queries on blockchain data
 - [Token Terminal](https://tokenterminal.com) - Protocol financials (revenue, fees, P/E ratios)
+- [Stablesonar](https://stablesonar.xyz) - Stablecoin yield radar: hourly-refreshed APYs ≥10% on USDC/USDT/DAI across every chain, with risk classification
 
 ### DEX & Trading
 - [DEX Screener](https://dexscreener.com) - Real-time charts for any DEX pair across all chains


### PR DESCRIPTION
Adds Stablesonar — a yield radar that tracks every USDC / USDT / DAI pool paying ≥ 10 % APY across all major DeFi chains, refreshed hourly.
Fits naturally next to DeFiLlama / Dune / Token Terminal in the DeFi Dashboards subsection: same category (analytics dashboards), narrower focus (stablecoin yields specifically).
- Website: https://stablesonar.xyz
- About / methodology: https://stablesonar.xyz/about
- ~600 pools currently tracked across 30+ chains
- Free, no signup or wallet connect
Happy to adjust placement, copy, or example if the maintainers prefer.