### PR TITLE
Add PoolDeFi (real historical LP APR analytics)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -209,6 +209,7 @@ On-chain fund management platforms.
 ### Advanced DeFi Tools
 - [DeFi Saver](https://defisaver.com) - Automation for lending positions (MakerDAO, Aave, Compound)
 - [Revert Finance](https://revert.finance) - Manage Uniswap V3 liquidity
+- [PoolDeFi](https://pooldefi.xyz) - Real historical APR of concentrated-liquidity pools from on-chain snapshots; multi-chain yield scanner, calculator, and IL planner
 - [Instadapp](https://instadapp.io) ([source code](https://github.com/Instadapp)) - Smart wallet for advanced DeFi interactions
 
 ### Developer Infrastructure


### PR DESCRIPTION
Adds PoolDeFi to **Advanced DeFi Tools**, alongside Revert Finance.

PoolDeFi is a free analytics tool that tracks the real, historical APR of concentrated-liquidity pools from on-chain snapshots (every 2h, stored permanently) across 6 chains (Base, Arbitrum, Polygon, BNB Chain, Avalanche, Monad) and 4 DEXes (Uniswap v3/v4, Aerodrome, PancakeSwap, LFJ). Includes a multi-chain yield scanner, an earnings calculator, and an impermanent-loss / range planner.

Disclosure: I'm the maker. It's free, no token, no signup required to browse.