### PR TITLE
Add AI Agent Tools section with TWZRD Agent Intel MCP server

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -215,6 +215,9 @@ On-chain fund management platforms.
 - [The Graph](https://thegraph.com) ([source code](https://github.com/graphprotocol), [docs](https://thegraph.com/docs/)) - Index and query blockchain data
 - [WalletConnect](https://walletconnect.com) ([source code](https://github.com/WalletConnect), [docs](https://docs.walletconnect.com/)) - Connect wallets to dapps
 
+### AI Agent Tools
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust-scoring MCP server for x402 agents on Solana. Free on-chain preflight checks trust + identity signals; signed USDC trust receipt (<$0.01, <1s). MCP URL: `https://intel.twzrd.xyz/mcp`
+
 <a name="analytics" />
 
 ## Analytics


### PR DESCRIPTION
## Summary

Adds a new **AI Agent Tools** subsection under Applications/Tools > Developer Infrastructure.

[TWZRD Agent Intel](https://intel.twzrd.xyz) is a trust-scoring MCP server for x402 agents on Solana:
- **Free preflight**: On-chain checks for wallet trust + identity signals
- **Paid receipt**: Signed USDC trust receipt (<$0.01, <1s settlement)
- **MCP URL**: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP)

As DeFi increasingly involves autonomous AI agents transacting on-chain, verifiable agent trust infrastructure becomes a core developer tool.