### PR TITLE
Add n.exchange to Cross-Chain DEX section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ Decentralized finance (#defi) is the movement that leverages open source softwar
 
 ### Cross-Chain
 - [THORChain](https://thorchain.org) ([source code](https://gitlab.com/thorchain), [docs](https://docs.thorchain.org/)) - Native cross-chain swaps (BTC, ETH, etc.) without wrapped tokens
+- [n.exchange](https://n.exchange) ([docs](https://docs.n.exchange/), [API](https://api.n.exchange/docs/v2)) - Non-custodial cross-chain swaps with single-transaction settlement, no wrapped tokens
 
 <a name="stablecoins" />
 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Decentralized finance (#defi) is the movement that leverages open source softwar
 
 ### Cross-Chain
 - [THORChain](https://thorchain.org) ([source code](https://gitlab.com/thorchain), [docs](https://docs.thorchain.org/)) - Native cross-chain swaps (BTC, ETH, etc.) without wrapped tokens
-- [n.exchange](https://n.exchange) ([docs](https://docs.n.exchange/), [API](https://api.n.exchange/docs/v2)) - Non-custodial cross-chain swaps with single-transaction settlement, no wrapped tokens
+- [n.exchange](https://n.exchange) ([docs](https://docs.n.exchange/), [API](https://api.n.exchange/docs/v2)) - Non-custodial cross-chain swaps with single-transaction settlement, no wrapped tokens; permissionless crypto-pair order API
 
 <a name="stablecoins" />
 


### PR DESCRIPTION
Adds n.exchange under "Decentralized Exchange Protocols → Cross-Chain".

n.exchange is a non-custodial cross-chain swap protocol that settles in a single transaction without wrapped tokens — the same bridgeless-settlement goal as the existing THORChain entry in this section. Supports 1,000+ pairs.

Docs: https://docs.n.exchange/ — API reference: https://api.n.exchange/docs/v2

Formatting follows the existing one-line entry style in the section, with two trailing links matching the adjacent THORChain entry.

Disclosure: I'm affiliated with n.exchange.
