### PR TITLE
Add Yieldo to Analytics › DeFi Dashboards

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -223,6 +223,7 @@ On-chain fund management platforms.
 - [DeFiLlama](https://defillama.com) ([source code](https://github.com/DefiLlama)) - Best DeFi data source: TVL, yields, stablecoins, unlocks across all chains
 - [Dune Analytics](https://dune.com) - Create custom dashboards with SQL queries on blockchain data
 - [Token Terminal](https://tokenterminal.com) - Protocol financials (revenue, fees, P/E ratios)
+- [Yieldo](https://yieldo.me) - Cross-exchange rates: staking APY, fees, network-freeze status, funding, and arbitrage across CEXs and DEXs
 
 ### DEX & Trading
 - [DEX Screener](https://dexscreener.com) - Real-time charts for any DEX pair across all chains


### PR DESCRIPTION
Adds **Yieldo** to Analytics › DeFi Dashboards.

Yieldo is a free cross-exchange rates aggregator: live staking APY, withdrawal fees with real-time network-availability ("withdrawal freeze") status, funding rates and arbitrage across 11 CEXs and DEXs (incl. STON.fi, Jupiter, and the Hyperliquid perp-DEX). Open JSON/CSV feeds at https://yieldo.me/about/data, no signup.

Single entry, follows the existing `[Name](url) - Description` format.
