### PR TITLE
Add TraderBear IL Calculator to Advanced DeFi Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -210,6 +210,7 @@ On-chain fund management platforms.
 - [DeFi Saver](https://defisaver.com) - Automation for lending positions (MakerDAO, Aave, Compound)
 - [Revert Finance](https://revert.finance) - Manage Uniswap V3 liquidity
 - [Instadapp](https://instadapp.io) ([source code](https://github.com/Instadapp)) - Smart wallet for advanced DeFi interactions
+- [TraderBear IL Calculator](https://trader-bear.com/impermanent-loss-calculator) - Free browser-based impermanent loss calculator for Solana (Raydium/Orca) and Uniswap pools; live pool inspector + Monte-Carlo LP-vs-HODL simulation
 
 ### Developer Infrastructure
 - [The Graph](https://thegraph.com) ([source code](https://github.com/graphprotocol), [docs](https://thegraph.com/docs/)) - Index and query blockchain data


### PR DESCRIPTION
Adds a free impermanent-loss / LP tool under **Advanced DeFi Tools**, alongside Revert Finance (which the list already includes for Uniswap V3 liquidity management).

**Entry:**
- [TraderBear IL Calculator](https://trader-bear.com/impermanent-loss-calculator) — Free browser-based impermanent loss calculator for Solana (Raydium/Orca) and Uniswap pools; live pool inspector + Monte-Carlo LP-vs-HODL simulation

**Why it fits:** it's a free, no-signup, entirely client-side tool for LPs to estimate IL before providing liquidity — including a Solana-native live pool inspector (paste a Raydium/Orca pool address, prices auto-fill) and a Monte-Carlo distribution of LP-vs-HODL outcomes with net APR, which the existing EVM-centric entries don't cover for Solana.

**Disclosure:** I'm affiliated with TraderBear. Happy to adjust the wording, description length, or placement — or to drop it if it's not a fit for the list. Thanks for maintaining this.