### PR TITLE
Add Cryptool to Portfolio Trackers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -202,6 +202,7 @@ On-chain fund management platforms.
 - [Safe](https://safe.global) ([source code](https://github.com/safe-global), [docs](https://docs.safe.global/)) - Multi-sig wallet (formerly Gnosis Safe)
 
 ### Portfolio Trackers
+- [Cryptool](https://cryptool.io) - Non-custodial multi-chain portfolio tracker with built-in fundraising, OTC, and fund management for investors and syndicates
 - [DeBank](https://debank.com) - Track positions across 1000+ protocols
 - [Zapper](https://zapper.xyz) - Portfolio tracker + easy DeFi interactions
 - [Zerion](https://zerion.io) ([source code](https://github.com/zeriontech)) - Portfolio + trading interface


### PR DESCRIPTION
Adds **Cryptool** ([cryptool.io](https://cryptool.io)) to the **Applications/Tools → Portfolio Trackers** list, alongside DeBank, Zapper, and Zerion.

Cryptool is a non-custodial, multi-chain portfolio tracker. Beyond tracking, it adds tools that the other trackers don't cover — fundraising/raises, syndicate and cap-table management, OTC, and fund administration — in one dashboard, with keys never leaving the user. Multi-chain/multi-wallet tracking; free tier available.

Single-line addition, placed alphabetically and matching the existing entry format. Thanks for maintaining the list!