### PR TITLE
Add Cryptool to portfolio trackers list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -203,6 +203,7 @@ On-chain fund management platforms.
 
 ### Portfolio Trackers
 - [DeBank](https://debank.com) - Track positions across 1000+ protocols
+- [Cryptool](https://cryptool.io) - Non-custodial multi-chain portfolio tracker with built-in fundraising, OTC, and fund management for investors and syndicates
 - [Zapper](https://zapper.xyz) - Portfolio tracker + easy DeFi interactions
 - [Zerion](https://zerion.io) ([source code](https://github.com/zeriontech)) - Portfolio + trading interface
 


### PR DESCRIPTION
Adds Cryptool (https://cryptool.io) to the Portfolio Trackers list, alongside DeBank, Zapper, and Zerion.

Cryptool is a non-custodial, multi-chain portfolio tracker. Beyond tracking, it adds fundraising, OTC, and fund-management tooling in one dashboard, with keys that never leave the user. Single-line addition matching the existing format. Thanks for maintaining the list!