### PR TITLE
Add LabelYX.com to DeFi Dashboards section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -223,6 +223,7 @@ On-chain fund management platforms.
 - [DeFiLlama](https://defillama.com) ([source code](https://github.com/DefiLlama)) - Best DeFi data source: TVL, yields, stablecoins, unlocks across all chains
 - [Dune Analytics](https://dune.com) - Create custom dashboards with SQL queries on blockchain data
 - [Token Terminal](https://tokenterminal.com) - Protocol financials (revenue, fees, P/E ratios)
+- [LabelYX](https://labelyx.com) - Hyperliquid trade tracker and analytics dashboard
 
 ### DEX & Trading
 - [DEX Screener](https://dexscreener.com) - Real-time charts for any DEX pair across all chains


### PR DESCRIPTION
Free, read-only analytics dashboard for Hyperliquid (decentralized perpetuals exchange) traders, plus a library of exchange-agnostic trading calculators and educational articles. No sign-up, no wallet connection, no custody — paste any public Hyperliquid wallet address to view its trading analytics.