### PR TITLE
Add AtlasYield to Analytics (Research & Intelligence)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -239,6 +239,7 @@ On-chain fund management platforms.
 - [Nansen](https://nansen.ai) - On-chain analytics with labeled wallets (tracks smart money)
 - [Arkham](https://arkaham.com) - Track entities and wallets
 - [Glassnode](https://glassnode.com) - On-chain metrics and market intelligence
+- [AtlasYield](https://atlasyield.club) ([score history](https://github.com/gveshk/atlasyield-score-history)) - Independent 0-100 ratings for DeFi yield vaults across 16 risk and return factors, with a public read-only scores API
 
 <a name="misc" />
 


### PR DESCRIPTION
Adds AtlasYield under Analytics → Research & Intelligence, alongside Messari/Nansen/Glassnode.

AtlasYield scores DeFi yield vaults 0-100 across 16 risk and return factors and publishes them through a public read-only scores API. The methodology is public and the timestamped score history is committed to an open repo: https://github.com/gveshk/atlasyield-score-history