### PR TITLE
Add BlazePhoenix to DEX Aggregators

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ Decentralized finance (#defi) is the movement that leverages open source softwar
 - [Matcha](https://matcha.xyz) - Aggregator by 0x with professional trading UI
 - [ParaSwap](https://paraswap.io) ([source code](https://github.com/paraswap)) - Multi-chain aggregator with MEV protection
 - [CoW Swap](https://cow.fi) ([source code](https://github.com/cowprotocol), [docs](https://docs.cow.fi/)) - MEV-protected trading via batch auctions and off-chain order matching
+- [BlazePhoenix](https://blazephoenix.xyz) ([source code](https://github.com/blazephoenixxyz-crypto), [docs](https://blazephoenix.xyz/agents)) - Fully on-chain aggregator: the quote is computed by the executing contract itself (reproducible via eth_call), with a contract-enforced output floor
 
 ### Solana
 - [Jupiter](https://jup.ag) ([source code](https://github.com/jup-ag)) - Leading Solana DEX aggregator with limit orders and DCA


### PR DESCRIPTION
Adds BlazePhoenix to the DEX Aggregators section (EVM).

What makes it a distinct entry rather than another aggregator: the quote shown to the user is computed by the same on-chain contract that executes the swap (Quoter.previewPlan, a free eth_call), so there is no off-chain pricing server in the trust model, and the output floor is enforced by the contract as a revert condition. Live on Base, Ethereum, Optimism, Arbitrum and Robinhood Chain; listed on DefiLlama (DEX Aggregators, id 8287); free keyless API + MCP server for agents.

Every claim above is reproducible from public chain state — e.g.:
`cast call 0x3f60C7aa0c36a78D200405feBE143d2Cf3fA0c77 "isSolvent()(bool)" --rpc-url https://mainnet.base.org`

Disclosure: PR prepared by an AI agent on behalf of the BlazePhoenix maintainer.